### PR TITLE
fix: OAuth request readonly permission changed to write/read

### DIFF
--- a/com.stansassets.google-doc-connector-pro/Editor/Core/GoogleDocConnectorEditor.cs
+++ b/com.stansassets.google-doc-connector-pro/Editor/Core/GoogleDocConnectorEditor.cs
@@ -97,7 +97,7 @@ namespace StansAssets.GoogleDoc.Editor
                     var credPath = $"{GoogleDocConnectorSettings.Instance.CredentialsFolderPath}/token.json";
                     await GoogleWebAuthorizationBroker.AuthorizeAsync(
                         GoogleClientSecrets.Load(stream).Secrets,
-                        new[] { SheetsService.Scope.SpreadsheetsReadonly },
+                        new[] { SheetsService.Scope.Spreadsheets },
                         "user",
                         CancellationToken.None,
                         new FileDataStore(credPath, true));


### PR DESCRIPTION
## Purpose of this PR
Fix of #78 issue (suggestion)
Adding soft dependency to com.stansassets.build won't work from the box without this fix

## Testing status
No automation tests performed

### Manual testing status
Tested manually with Unity Editor