### PR TITLE
chore: com.stansassets.newtonjson replaced with com.unity.nuget.newtonsoft-json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ sysinfo.txt
 *.apk
 *.unitypackage
 
+# Mac OS Spesific
+*.DS_Store
+
 # Crashlytics generated file
 crashlytics-build.properties
 

--- a/com.stansassets.google-doc-connector-pro/package.json
+++ b/com.stansassets.google-doc-connector-pro/package.json
@@ -1,13 +1,13 @@
 {
   "name": "com.stansassets.google-doc-connector-pro",
   "displayName": "Stans Assets - Google Doc Connector Pro",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "unity": "2020.1",
   "description": "The plugin allows you to use Google Sheets as a configuration repository for your game. And also use Google Sheets as a repository for localization.",
   "dependencies": {
     "com.stansassets.foundation": "1.0.21",
     "com.stansassets.plugins-dev-kit": "1.0.3",
-    "com.stansassets.newtonjson" : "12.0.101"
+    "com.unity.nuget.newtonsoft-json" : "3.2.0"
   },
   "author": {
     "name": "Stan's Assets",


### PR DESCRIPTION
## Purpose of this PR
Replacing `com.stansassets.newtonjson  dependency` with `com.unity.nuget.newtonsoft-json`
Also Mac OS specific files were added to the git ignore list.

## Testing status
* No tests have been added.

### Manual testing status
Tested in the editor using Roomful credentials.
